### PR TITLE
gadgetd backend removal and cross-compilation instruction

### DIFF
--- a/examples/cross-compile/README.rst
+++ b/examples/cross-compile/README.rst
@@ -1,0 +1,94 @@
+SPDX-License-Identifier: CC-BY-SA-4.0
+
+Copyright 2019 Collabora Ltd
+
+Author: Andrzej Pietrasiewicz <andrzej.p@collabora.com>
+
+==================
+cross compiling gt
+==================
+
+Purpose of this document
+========================
+
+The purpose of this document is to explaing how gt can be cross-compiled for
+arm platform, when not compiling with gadgetd support.
+
+User story
+==========
+
+A developer wants to cross compile gt for arm from sources. gt depends on
+libusbgx which also needs to be cross compiled. It also depends on libconfig9.
+
+The idea
+========
+
+The idea is to have a target root file system with libconfig9 installed and
+cross compile and install libusbgx there, and then cross compile and install
+gt. The compiler shall be invoked with --sysroot pointing to the target root
+file system.
+
+Cross compiling
+===============
+
+We assume that ${ROOTFS} contains a path where in the compilation host the
+target root file system can be found.
+
+We assume that compilation is for armhf.
+
+The target root file system should already contain libconfig-dev and
+libconfig9. They can be installed natively by the target system in its root
+file system.
+
+libusbgx
+--------
+
+.. code-block:: console
+
+	PKG_CONFIG_PATH=${ROOTFS}/usr/lib/arm-linux-gnueabihf/pkgconfig	\
+		./configure 						\
+			--host=arm-linux-gnueabihf --prefix=/usr 	\
+			--with-sysroot=${ROOTFS}/debian-stretch-armhf
+	make CFLAGS="--sysroot=${ROOTFS}"
+	make DESTDIR=${ROOTFS} install
+
+The --prefix refers only to the location in the target system, whose root
+on the cross compilation host can be found at ${DESTDIR}.
+
+gt
+--
+
+As gt is built with cmake, the cross compilation toolchain must be specified
+as a text file, let's call it armhf-toolchain.txt:
+
+.. code-block:: console
+
+	set(CMAKE_SYSTEM_NAME Linux)
+	set(CMAKE_SYSTEM_PROCESSOR arm)
+
+	set(CMAKE_SYSROOT ${ROOTFS})
+
+	set(CMAKE_C_COMPILER arm-linux-gnueabihf-gcc)
+
+	set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+	set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+	set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+	set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+Then the invocation of cmake follows:
+
+.. code-block:: console
+
+	PKG_CONFIG_PATH=${ROOTFS}/usr/lib/pkgconfig:			\
+		${ROOTFS}/usr/lib/arm-linux-gnueabihf/pkgconfig 	\
+		cmake 							\
+			-DCMAKE_INSTALL_PREFIX=${ROOTFS} 		\
+			-DCMAKE_RUNTIME_PREFIX=/ 			\
+			-DCMAKE_TOOLCHAIN_FILE=armhf-toolchain.txt
+
+And then:
+
+.. code-block:: console
+
+	make
+	make install

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -21,10 +21,16 @@ ADD_DEFINITIONS("-DPREFIX=\"${PREFIX}\"")
 
 SET(PKG_MODULES
         libusbgx>=0.2.0
-	glib-2.0
-	gio-2.0
 	libconfig
 )
+
+IF (DEFINED CMAKE_WITH_GADGETD)
+	ADD_DEFINITIONS("-DWITH_GADGETD=1")
+	LIST(APPEND PKG_MODULES
+		glib-2.0
+		gio-2.0
+	)
+ENDIF ()
 
 INCLUDE(FindPkgConfig)
 pkg_check_modules(pkgs REQUIRED ${PKG_MODULES})

--- a/source/base/include/backend.h
+++ b/source/base/include/backend.h
@@ -23,7 +23,9 @@
 #define __GADGET_TOOL_BACKEND_H__
 
 #include <usbg/usbg.h>
+#ifdef WITH_GADGETD
 #include <gio/gio.h>
+#endif
 #include "parser.h"
 
 /**
@@ -38,7 +40,9 @@ int gt_backend_init(const char *program_name, enum gt_option_flags flags);
  */
 enum gt_backend_type {
 	GT_BACKEND_AUTO = 0,
+#ifdef WITH_GADGETD
 	GT_BACKEND_GADGETD,
+#endif
 	GT_BACKEND_LIBUSBG,
 	GT_BACKEND_NOT_IMPLEMENTED,
 };
@@ -57,12 +61,16 @@ struct gt_backend_ctx {
 
 	union {
 		usbg_state *libusbg_state;
+#ifdef WITH_GADGETD
 		GDBusConnection *gadgetd_conn;
+#endif
 	};
 };
 
 extern struct gt_backend gt_backend_libusbg;
+#ifdef WITH_GADGETD
 extern struct gt_backend gt_backend_gadgetd;
+#endif
 extern struct gt_backend gt_backend_not_implemented;
 
 extern struct gt_backend_ctx backend_ctx;

--- a/source/base/include/common.h
+++ b/source/base/include/common.h
@@ -18,7 +18,9 @@
 #define __GADGET_TOOL_COMMON_H__
 
 #include <stdlib.h>
+#ifdef WITH_GADGETD
 #include <gio/gio.h>
+#endif
 
 /**
  * @brief Short program name
@@ -36,16 +38,20 @@ static inline void *zalloc(size_t size)
 
 #define ARRAY_SIZE(array) sizeof(array)/sizeof(*array)
 
+#ifdef WITH_GADGETD
 static inline void _cleanup_fn_g_free_(void *p) {
 	g_free(*(gpointer *)p);
 }
+#endif
 
 static inline void _cleanup_fn_free_(void *p) {
 	free(*(void **)p);
 }
 
 #define _cleanup_(fn)   __attribute__((cleanup(fn)))
+#ifdef WITH_GADGETD
 #define _cleanup_g_free_ _cleanup_(_cleanup_fn_g_free_)
+#endif
 #define _cleanup_free_  _cleanup_(_cleanup_fn_free_)
 
 #endif //__GADGET_TOOL_COMMON_H__

--- a/source/config/CMakeLists.txt
+++ b/source/config/CMakeLists.txt
@@ -3,9 +3,14 @@ INCLUDE_DIRECTORIES( ${CMAKE_CURRENT_SOURCE_DIR}/include )
 
 SET( CONFIG_SRC
 	${CMAKE_CURRENT_SOURCE_DIR}/src/configuration.c
-	${CMAKE_CURRENT_SOURCE_DIR}/src/configuration_gadgetd.c
 	${CMAKE_CURRENT_SOURCE_DIR}/src/configuration_libusbg.c
 	${CMAKE_CURRENT_SOURCE_DIR}/src/configuration_not_implemented.c
 	)
+
+IF (DEFINED CMAKE_WITH_GADGETD)
+	LIST(APPEND CONFIG_SRC
+		${CMAKE_CURRENT_SOURCE_DIR}/src/configuration_gadgetd.c
+	)
+ENDIF ()
 
 add_library(config STATIC ${CONFIG_SRC} )

--- a/source/config/include/configuration.h
+++ b/source/config/include/configuration.h
@@ -194,7 +194,9 @@ int gt_config_help(void *data);
  */
 int gt_print_config_libusbg(usbg_config *c, int opts);
 
+#ifdef WITH_GADGETD
 extern struct gt_config_backend gt_config_backend_gadgetd;
+#endif
 extern struct gt_config_backend gt_config_backend_libusbg;
 extern struct gt_config_backend gt_config_backend_not_implemented;
 

--- a/source/config/src/configuration.c
+++ b/source/config/src/configuration.c
@@ -26,7 +26,9 @@
 #include "backend.h"
 
 #include <errno.h>
+#ifdef WITH_GADGETD
 #include <gio/gio.h>
+#endif
 
 #define GET_EXECUTABLE(func) \
 	(backend_ctx.backend->config->func ? \

--- a/source/config/src/configuration_libusbg.c
+++ b/source/config/src/configuration_libusbg.c
@@ -63,7 +63,11 @@ static int add_func(void *data)
 	usbg_config *c;
 	int n;
 	char buff[255];
+#ifdef WITH_GADGETD
 	_cleanup_g_free_ gchar *func_name = NULL;
+#else
+	_cleanup_free_ char *func_name = NULL;
+#endif
 	const char *cfg_label = NULL;
 
 	dt = (struct gt_config_add_del_data *)data;

--- a/source/function/CMakeLists.txt
+++ b/source/function/CMakeLists.txt
@@ -4,8 +4,13 @@ INCLUDE_DIRECTORIES( ${CMAKE_CURRENT_SOURCE_DIR}/include )
 SET( FUNCTION_SRC
 	${CMAKE_CURRENT_SOURCE_DIR}/src/function.c
 	${CMAKE_CURRENT_SOURCE_DIR}/src/function_libusbg.c
-	${CMAKE_CURRENT_SOURCE_DIR}/src/function_gadgetd.c
 	${CMAKE_CURRENT_SOURCE_DIR}/src/function_not_implemented.c
 	)
+
+IF (DEFINED CMAKE_WITH_GADGETD)
+	LIST(APPEND FUNCTION_SRC
+		${CMAKE_CURRENT_SOURCE_DIR}/src/function_gadgetd.c
+	)
+ENDIF ()
 
 add_library(function STATIC ${FUNCTION_SRC} )

--- a/source/function/include/function.h
+++ b/source/function/include/function.h
@@ -179,7 +179,9 @@ int gt_func_help(void *data);
 int gt_print_function_libusbg(usbg_function *f, int opts);
 
 extern struct gt_function_backend gt_function_backend_libusbg;
+#ifdef WITH_GADGETD
 extern struct gt_function_backend gt_function_backend_gadgetd;
+#endif
 extern struct gt_function_backend gt_function_backend_not_implemented;
 
 #endif //__GADGET_TOOL_FUNCTION_FUNCTION_H__

--- a/source/gadget/CMakeLists.txt
+++ b/source/gadget/CMakeLists.txt
@@ -6,8 +6,13 @@ INCLUDE_DIRECTORIES( ${CMAKE_CURRENT_SOURCE_DIR}/include
 SET( GADGET_SRC
 	${CMAKE_CURRENT_SOURCE_DIR}/src/gadget.c
 	${CMAKE_CURRENT_SOURCE_DIR}/src/gadget_libusbg.c
-	${CMAKE_CURRENT_SOURCE_DIR}/src/gadget_gadgetd.c
 	${CMAKE_CURRENT_SOURCE_DIR}/src/gadget_not_implemented.c
 	)
+
+IF (DEFINED CMAKE_WITH_GADGETD)
+	LIST(APPEND GADGET_SRC
+		${CMAKE_CURRENT_SOURCE_DIR}/src/gadget_gadgetd.c
+	)
+ENDIF ()
 
 add_library(gadget STATIC ${GADGET_SRC} )

--- a/source/gadget/include/gadget.h
+++ b/source/gadget/include/gadget.h
@@ -189,7 +189,9 @@ const Command *get_gadget_children(const Command *cmd);
  */
 int gt_gadget_help(void *data);
 
+#ifdef WITH_GADGETD
 extern struct gt_gadget_backend gt_gadget_backend_gadgetd;
+#endif
 extern struct gt_gadget_backend gt_gadget_backend_libusbg;
 extern struct gt_gadget_backend gt_gadget_backend_not_implemented;
 

--- a/source/gadget/src/gadget.c
+++ b/source/gadget/src/gadget.c
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+#ifndef WITH_GADGETD
+#include <stdbool.h>
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -116,7 +119,11 @@ static int gt_parse_gadget_attrs(struct gt_setting *attrs, int *attr_val, char *
 	int i;
 
 	for (setting = attrs; setting->variable; setting++) {
+#ifdef WITH_GADGETD
 		iter = TRUE;
+#else
+		iter = true;
+#endif
 
 		attr_id = usbg_lookup_gadget_attr(setting->variable);
 		if (attr_id >= 0) {
@@ -136,13 +143,21 @@ static int gt_parse_gadget_attrs(struct gt_setting *attrs, int *attr_val, char *
 			}
 
 			attr_val[attr_id] = val;
+#ifdef WITH_GADGETD
 			iter = FALSE;
+#else
+			iter = false;
+#endif
 		}
 
 		for (i = 0; iter && i < GT_GADGET_STRS_COUNT; i++) {
 			if (streq(setting->variable, gadget_strs[i].name)) {
 				str_val[i] = setting->value;
+#ifdef WITH_GADGETD
 				iter = FALSE;
+#else
+				iter = false;
+#endif
 				break;
 			}
 		}

--- a/source/gadget/src/gadget_libusbg.c
+++ b/source/gadget/src/gadget_libusbg.c
@@ -26,6 +26,10 @@
 #include "function.h"
 #include "configuration.h"
 
+#ifndef WITH_GADGETD
+#define G_N_ELEMENTS(arr)	(sizeof(arr) / sizeof((arr)[0]))
+#endif
+
 /**
  * @brief Get implicite gadget
  * @param[in] s Usbg state

--- a/source/manpages/gt.1.txt
+++ b/source/manpages/gt.1.txt
@@ -19,7 +19,9 @@ This tool can be used to create and configure usb gadgets using configfs.
 It can be executed in two different ways:
 
 * *gt* operates directly on configfs, which requires root privileges.
-* *gadgetctl* use gadgetd daemon to configure gadgets.
+* *gadgetctl* use gadgetd daemon to configure gadgets (if built with gadgetd support)
+
+Note: gadgetd is considered obsolete.
 
 Both commands provide the same syntax described below.
 
@@ -200,4 +202,5 @@ When you want to reload saved gadget, simply run:
 
 	$ gt load ether.scheme g1
 
-When you have gadgetd daemon running, you can replace *gt* with *gadgetctl*.
+When you have gadgetd daemon running, you can replace *gt* with *gadgetctl*,
+if gt has been built with gadgetd support.

--- a/source/udc/CMakeLists.txt
+++ b/source/udc/CMakeLists.txt
@@ -4,8 +4,13 @@ INCLUDE_DIRECTORIES( ${CMAKE_CURRENT_SOURCE_DIR}/include )
 SET( UDC_SRC
 	${CMAKE_CURRENT_SOURCE_DIR}/src/udc.c
 	${CMAKE_CURRENT_SOURCE_DIR}/src/udc_libusbg.c
-	${CMAKE_CURRENT_SOURCE_DIR}/src/udc_gadgetd.c
 	${CMAKE_CURRENT_SOURCE_DIR}/src/udc_not_implemented.c
 	)
+
+IF (DEFINED CMAKE_WITH_GADGETD)
+	LIST(APPEND UDC_SRC
+		${CMAKE_CURRENT_SOURCE_DIR}/src/udc_gadgetd.c
+	)
+ENDIF ()
 
 add_library(udc STATIC ${UDC_SRC} )

--- a/source/udc/include/udc.h
+++ b/source/udc/include/udc.h
@@ -43,7 +43,9 @@ void udc_parse(const Command *cmd, int argc, char **argv,
 		ExecutableCommand *exec, void * data);
 
 extern struct gt_udc_backend gt_udc_backend_libusbg;
+#ifdef WITH_GADGETD
 extern struct gt_udc_backend gt_udc_backend_gadgetd;
+#endif
 extern struct gt_udc_backend gt_udc_backend_not_implemented;
 
 #endif //__GADGET_TOOL_UDC_UDC_PARSE_H__


### PR DESCRIPTION
gadgetd backend seems abandoned. Is it? If yes, it makes sense to remove it. Then dependency on glib and gio is not in fact needed so this is also removed.

Since gt is very useful for the embedded world, it makes sense to document how to cross-compile it.